### PR TITLE
Adding missing requirement to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai
 faiss-cpu
 streamlit
 streamlit-chat
+tiktoken


### PR DESCRIPTION
## Proposed changes

Tiny tweak adding openai's tiktoken which seems to be required to run qa.py script